### PR TITLE
I've updated the project configuration files (OpenCV_Debug.props and …

### DIFF
--- a/src/Tracking_101/OpenCV_Debug.props
+++ b/src/Tracking_101/OpenCV_Debug.props
@@ -9,7 +9,7 @@
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(OPENCV_DIR)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>opencv_world310d.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>opencv_world4110d.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
   </ItemDefinitionGroup>

--- a/src/Tracking_101/OpenCV_Release.props
+++ b/src/Tracking_101/OpenCV_Release.props
@@ -9,7 +9,7 @@
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(OPENCV_DIR)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>opencv_world310.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>opencv_world4110.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
   </ItemDefinitionGroup>


### PR DESCRIPTION
…OpenCV_Release.props) to reference the OpenCV 4.11.0 libraries (opencv_world4110d.lib and opencv_world4110.lib).

IMPORTANT: You will need to manually update your OPENCV_DIR environment variable to point to the root directory of your OpenCV 4.11.0 installation for these changes to take effect and for the project to build correctly.